### PR TITLE
Fix for issue where output directory is not correctly created when co…

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -98,7 +98,10 @@ then
 	exit `false`;
 fi
 
-[ ! -d ${output_dir} ] || mkdir ${output_dir}
+if [ ! -d ${output_dir} ];
+then
+	mkdir ${output_dir};
+fi
 
 # copy makefiles
 (cd ${ABS_PATH}/mk; tar cf - . ) | ( cd ${output_dir}; tar xf - );


### PR DESCRIPTION
…nfigure.sh is called

when folder test doesnt already exist :

$ ./configure.sh test
./configure.sh: 104: cd: can't cd to test
mkdir: cannot create directory ‘test/tests/fixtures’: No such file or directory
cp: cannot create regular file ‘test/tests/include/TestHelper.hpp’: No such file or directory
cp: cannot create regular file ‘test/tests/src/’: No such file or directory
cp: cannot create regular file ‘test/tests/lib’: No such file or directory
cp: cannot create regular file ‘test/tests/fixtures/’: No such file or directory
./configure.sh: 114: ./configure.sh: cannot create test/configure.ac: Directory nonexistent
